### PR TITLE
Add Notification Feature for Completed Repairs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Environment files (do not commit sensitive info)
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# PerbaikiinAja - Order Service
+
+This project is responsible for managing the full process of placing and handling repair service requests, from initial order creation to final completion. Users can place new repair orders, specifying item details, desired repairs, choosing a payment method, and optionally selecting their preferred technician. Technicians receive these orders, provide cost and time estimates, and update the order status as repairs progress. After technicians mark repairs as completed, users receive notifications and can view, manage, or delete these notifications to stay informed without clutter.
+
+## API Reference
+
+### Notifications Endpoints
+
+All endpoints in this section require a valid JWT token in the `Authorization` header:
+
+`Authorization: Bearer <jwt-token>`
+
+#### Get Notifications
+
+```http
+GET /notifications
+```
+
+**Description:**  
+Retrieves a list of notifications for the authenticated user. When the notifications are retrieved, their status will be updated so that each notification’s `isRead` flag is set to `true`.
+
+**Response:**
+
+```json
+[
+  {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "userId": "a3dda38c-0819-4ee0-ba4f-f124180219e9",
+    "title": "Repair Completed",
+    "message": "Your repair request #12345 has been completed.",
+    "isRead": true,
+    "createdAt": "2025-04-09T20:54:40"
+  },
+  {
+    "id": "c9bf9e57-1685-4c89-bafb-ff5af830be8a",
+    "userId": "a3dda38c-0819-4ee0-ba4f-f124180219e9",
+    "title": "Repair Completed",
+    "message": "Your repair request #67890 has been completed.",
+    "isRead": true,
+    "createdAt": "2025-04-09T21:00:10"
+  }
+]
+```
+
+---
+
+#### Delete Notification
+
+```http
+DELETE /notifications/{notificationId}
+```
+
+**Description:**  
+Deletes a single notification by its ID if it belongs to the authenticated user.
+
+**Path Parameter:**
+
+| Parameter       | Type   | Description                      |
+| --------------- | ------ | -------------------------------- |
+| `notificationId` | UUID  | **Required**. ID of the notification to delete. |
+
+**Response:**  
+A successful response returns an HTTP 200 status. If the notification is not found or the user is not authorized to delete it, an error message is returned.
+
+---
+
+## Environment Configuration
+
+Before running the application, create a `.env` file in the project root with the following example settings. Replace these dummy values with your actual configuration as needed.
+
+```dotenv
+# Database
+DATABASE_URL=jdbc:postgresql://localhost:5432/perbaikiinaja
+DATABASE_USERNAME=your_db_username
+DATABASE_PASSWORD=your_db_password
+
+# Hibernate / JPA
+HIBERNATE_DIALECT=org.hibernate.dialect.PostgreSQLDialect
+JPA_DDL_AUTO=update
+SHOW_SQL=true
+
+# JWT
+# The decoded secret must be at least 512 bits (64 bytes) in length.
+JWT_SECRET="your_jwt_secret_key"
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     java
+    jacoco
     id("org.springframework.boot") version "3.4.4"
     id("io.spring.dependency-management") version "1.1.7"
 }
@@ -26,6 +27,20 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    testImplementation("org.springframework.security:spring-security-test:6.0.2")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+    runtimeOnly("org.postgresql:postgresql:42.6.0")
+    runtimeOnly("com.h2database:h2:2.2.220")
+
+    implementation("io.github.cdimascio:java-dotenv:5.2.2")
+
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
@@ -34,6 +49,36 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
-tasks.withType<Test> {
+tasks.register<Test>("unitTest") {
+    description = "Runs unit tests."
+    group = "verification"
+
+    filter {
+        excludeTestsMatching("*FunctionalTest")
+    }
+}
+
+tasks.register<Test>("functionalTest") {
+    description = "Runs functional tests."
+    group = "verification"
+
+    filter {
+        includeTestsMatching("*FunctionalTest")
+    }
+}
+
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+}
+
+tasks.test {
+    filter {
+        excludeTestsMatching("*FunctionalTest")
+    }
+
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
 }

--- a/src/main/java/id/ac/ui/cs/advprog/order/OrderApplication.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/OrderApplication.java
@@ -3,11 +3,26 @@ package id.ac.ui.cs.advprog.order;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import io.github.cdimascio.dotenv.Dotenv;
+
 @SpringBootApplication
 public class OrderApplication {
 
     public static void main(String[] args) {
+
+        String activeProfile = System.getProperty("spring.profiles.active");
+        if (!"test".equals(activeProfile)) {
+            Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+
+            System.setProperty("spring.datasource.url", dotenv.get("DATABASE_URL"));
+            System.setProperty("spring.datasource.username", dotenv.get("DATABASE_USERNAME"));
+            System.setProperty("spring.datasource.password", dotenv.get("DATABASE_PASSWORD"));
+
+            System.setProperty("spring.jpa.properties.hibernate.dialect", dotenv.get("HIBERNATE_DIALECT"));
+            System.setProperty("spring.jpa.hibernate.ddl-auto", dotenv.get("JPA_DDL_AUTO"));
+            System.setProperty("spring.jpa.show-sql", dotenv.get("SHOW_SQL"));
+        }
+
         SpringApplication.run(OrderApplication.class, args);
     }
-
 }

--- a/src/main/java/id/ac/ui/cs/advprog/order/config/DotenvConfig.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/config/DotenvConfig.java
@@ -1,0 +1,17 @@
+package id.ac.ui.cs.advprog.order.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.github.cdimascio.dotenv.Dotenv;
+
+@Configuration
+public class DotenvConfig {
+
+    @Bean
+    public Dotenv dotenv() {
+        return Dotenv.configure()
+                .ignoreIfMissing()
+                .load();
+    }
+}

--- a/src/main/java/id/ac/ui/cs/advprog/order/config/SecurityConfig.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package id.ac.ui.cs.advprog.order.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import id.ac.ui.cs.advprog.order.security.JwtAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/notifications/**").authenticated()
+                        .anyRequest().permitAll()
+                )
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                );
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/main/java/id/ac/ui/cs/advprog/order/controller/NotificationController.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/controller/NotificationController.java
@@ -1,0 +1,37 @@
+package id.ac.ui.cs.advprog.order.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import id.ac.ui.cs.advprog.order.model.Notification;
+import id.ac.ui.cs.advprog.order.service.NotificationService;
+
+@RestController
+@RequestMapping("/notifications")
+@PreAuthorize("hasRole('USER')")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Autowired
+    public NotificationController(NotificationService notificationService) {
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Notification>> getNotifications(Authentication auth) {
+    }
+
+    @DeleteMapping("/{notificationId}")
+    public ResponseEntity<?> deleteNotification(@PathVariable UUID notificationId, Authentication auth) {
+    }
+}

--- a/src/main/java/id/ac/ui/cs/advprog/order/controller/NotificationController.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/controller/NotificationController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,13 +26,35 @@ public class NotificationController {
 
     @Autowired
     public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    private UUID extractUserId(Authentication auth) {
+        Object principal = auth.getPrincipal();
+        if (principal instanceof String) {
+            return UUID.fromString((String) principal);
+        } else if (principal instanceof User) {
+            return UUID.fromString(((User) principal).getUsername());
+        } else {
+            throw new IllegalStateException("Unexpected principal type: " + principal.getClass());
+        }
     }
 
     @GetMapping
     public ResponseEntity<List<Notification>> getNotifications(Authentication auth) {
+        UUID userId = extractUserId(auth);
+        List<Notification> notifications = notificationService.getNotifications(userId);
+        return ResponseEntity.ok(notifications);
     }
 
     @DeleteMapping("/{notificationId}")
     public ResponseEntity<?> deleteNotification(@PathVariable UUID notificationId, Authentication auth) {
+        UUID userId = extractUserId(auth);
+        try {
+            notificationService.deleteNotification(notificationId, userId);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/id/ac/ui/cs/advprog/order/model/Notification.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/model/Notification.java
@@ -1,8 +1,14 @@
 package id.ac.ui.cs.advprog.order.model;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.hibernate.annotations.GenericGenerator;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.Generated;
@@ -13,8 +19,34 @@ import lombok.Generated;
 @Data
 public class Notification {
 
+    @Id
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name="UUID", strategy="org.hibernate.id.UUIDGenerator")
+    @Column(name="id", updatable=false, nullable=false)
+    private UUID id;
+
+    @Column(name="user_id", nullable=false)
+    private UUID userId;
+
+    @Column(name="title", nullable=false)
+    private String title;
+
+    @Column(name="message", nullable=false)
+    private String message;
+
+    @Column(name="is_read", nullable=false)
+    private boolean isRead = false;
+
+    @Column(name="created_at", nullable=false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
     public Notification() {}
 
     public Notification(UUID userId, String title, String message) {
+        this.userId = userId;
+        this.title = title;
+        this.message = message;
+        this.createdAt = LocalDateTime.now();
+        this.isRead = false;
     }
 }

--- a/src/main/java/id/ac/ui/cs/advprog/order/model/Notification.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/model/Notification.java
@@ -1,0 +1,20 @@
+package id.ac.ui.cs.advprog.order.model;
+
+import java.util.UUID;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.Generated;
+
+@Entity
+@Table(name = "notifications")
+@Generated
+@Data
+public class Notification {
+
+    public Notification() {}
+
+    public Notification(UUID userId, String title, String message) {
+    }
+}

--- a/src/main/java/id/ac/ui/cs/advprog/order/repository/NotificationRepository.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package id.ac.ui.cs.advprog.order.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import id.ac.ui.cs.advprog.order.model.Notification;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+}

--- a/src/main/java/id/ac/ui/cs/advprog/order/repository/NotificationRepository.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/repository/NotificationRepository.java
@@ -1,5 +1,6 @@
 package id.ac.ui.cs.advprog.order.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,5 @@ import id.ac.ui.cs.advprog.order.model.Notification;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+    List<Notification> findByUserId(UUID userId);
 }

--- a/src/main/java/id/ac/ui/cs/advprog/order/security/JwtAuthenticationFilter.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/security/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package id.ac.ui.cs.advprog.order.security;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                if (jwtTokenProvider.validateToken(token)) {
+                    String userId = jwtTokenProvider.getUserIdFromJWT(token);
+                    String role = jwtTokenProvider.getRoleFromJWT(token);
+
+                    List<SimpleGrantedAuthority> authorities =
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role.toUpperCase()));
+
+                    UsernamePasswordAuthenticationToken auth =
+                            new UsernamePasswordAuthenticationToken(userId, null, authorities);
+
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                }
+            } catch (JwtException ex) {
+                // token invalid or expired
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/id/ac/ui/cs/advprog/order/security/JwtTokenProvider.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/security/JwtTokenProvider.java
@@ -1,0 +1,52 @@
+package id.ac.ui.cs.advprog.order.security;
+
+import java.security.Key;
+
+import org.springframework.stereotype.Component;
+
+import io.github.cdimascio.dotenv.Dotenv;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtTokenProvider {
+
+    private final String jwtSecret;
+
+    public JwtTokenProvider() {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        this.jwtSecret = dotenv.get("JWT_SECRET");
+    }
+
+    private Key getSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(jwtSecret);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String getUserIdFromJWT(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(getSigningKey())
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+
+    public String getRoleFromJWT(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(getSigningKey())
+                .parseClaimsJws(token)
+                .getBody();
+        return (String) claims.get("role");
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(getSigningKey()).parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/id/ac/ui/cs/advprog/order/service/NotificationService.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/service/NotificationService.java
@@ -1,0 +1,15 @@
+package id.ac.ui.cs.advprog.order.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import id.ac.ui.cs.advprog.order.model.Notification;
+
+public interface NotificationService {
+
+    Notification createNotification(UUID userId, String title, String message);
+
+    List<Notification> getNotifications(UUID userId);
+
+    void deleteNotification(UUID notificationId, UUID userId) throws Exception;
+}

--- a/src/main/java/id/ac/ui/cs/advprog/order/service/NotificationServiceImpl.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/service/NotificationServiceImpl.java
@@ -1,6 +1,7 @@
 package id.ac.ui.cs.advprog.order.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,17 +17,37 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Autowired
     public NotificationServiceImpl(NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
     }
 
     @Override
     public Notification createNotification(UUID userId, String title, String message) {
+        Notification notification = new Notification(userId, title, message);
+        return notificationRepository.save(notification);
     }
 
     @Override
     public List<Notification> getNotifications(UUID userId) {
+        List<Notification> notifications = notificationRepository.findByUserId(userId);
+        notifications.forEach(notification -> {
+            if (!notification.isRead()) {
+                notification.setRead(true);
+                notificationRepository.save(notification);
+            }
+        });
+        return notifications;
     }
 
     @Override
     public void deleteNotification(UUID notificationId, UUID userId) throws Exception {
+        Optional<Notification> optional = notificationRepository.findById(notificationId);
+        if (optional.isEmpty()) {
+            throw new Exception("Notification not found");
+        }
+        Notification notification = optional.get();
+        if (!notification.getUserId().equals(userId)) {
+            throw new Exception("Not authorized to delete this notification");
+        }
+        notificationRepository.deleteById(notificationId);
     }
 }

--- a/src/main/java/id/ac/ui/cs/advprog/order/service/NotificationServiceImpl.java
+++ b/src/main/java/id/ac/ui/cs/advprog/order/service/NotificationServiceImpl.java
@@ -1,0 +1,32 @@
+package id.ac.ui.cs.advprog.order.service;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import id.ac.ui.cs.advprog.order.model.Notification;
+import id.ac.ui.cs.advprog.order.repository.NotificationRepository;
+
+@Service
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Autowired
+    public NotificationServiceImpl(NotificationRepository notificationRepository) {
+    }
+
+    @Override
+    public Notification createNotification(UUID userId, String title, String message) {
+    }
+
+    @Override
+    public List<Notification> getNotifications(UUID userId) {
+    }
+
+    @Override
+    public void deleteNotification(UUID notificationId, UUID userId) throws Exception {
+    }
+}

--- a/src/test/java/id/ac/ui/cs/advprog/order/controller/NotificationControllerTest.java
+++ b/src/test/java/id/ac/ui/cs/advprog/order/controller/NotificationControllerTest.java
@@ -1,0 +1,46 @@
+package id.ac.ui.cs.advprog.order.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import id.ac.ui.cs.advprog.order.security.JwtTokenProvider;
+import id.ac.ui.cs.advprog.order.service.NotificationService;
+
+@WebMvcTest(NotificationController.class)
+@Import(id.ac.ui.cs.advprog.order.config.SecurityConfig.class)
+public class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(username = "00000000-0000-0000-0000-000000000001", roles = {"USER"})
+    void testGetNotifications() throws Exception {
+    }
+
+    @Test
+    @WithMockUser(username = "00000000-0000-0000-0000-000000000001", roles = {"USER"})
+    void testDeleteNotificationSuccess() throws Exception {
+    }
+
+    @Test
+    @WithMockUser(username = "00000000-0000-0000-0000-000000000001", roles = {"USER"})
+    void testDeleteNotificationNotFound() throws Exception {
+    }
+}

--- a/src/test/java/id/ac/ui/cs/advprog/order/controller/NotificationControllerTest.java
+++ b/src/test/java/id/ac/ui/cs/advprog/order/controller/NotificationControllerTest.java
@@ -1,6 +1,18 @@
 package id.ac.ui.cs.advprog.order.controller;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -10,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import id.ac.ui.cs.advprog.order.model.Notification;
 import id.ac.ui.cs.advprog.order.security.JwtTokenProvider;
 import id.ac.ui.cs.advprog.order.service.NotificationService;
 
@@ -32,15 +45,41 @@ public class NotificationControllerTest {
     @Test
     @WithMockUser(username = "00000000-0000-0000-0000-000000000001", roles = {"USER"})
     void testGetNotifications() throws Exception {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        Notification n1 = new Notification(userId, "Title1", "Message1");
+        n1.setId(UUID.randomUUID());
+        Notification n2 = new Notification(userId, "Title2", "Message2");
+        n2.setId(UUID.randomUUID());
+        List<Notification> notifications = Arrays.asList(n1, n2);
+        Mockito.when(notificationService.getNotifications(userId)).thenReturn(notifications);
+
+        mockMvc.perform(get("/notifications").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("Title1"))
+                .andExpect(jsonPath("$[1].title").value("Title2"));
     }
 
     @Test
     @WithMockUser(username = "00000000-0000-0000-0000-000000000001", roles = {"USER"})
     void testDeleteNotificationSuccess() throws Exception {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID notificationId = UUID.randomUUID();
+        Mockito.doNothing().when(notificationService).deleteNotification(notificationId, userId);
+
+        mockMvc.perform(delete("/notifications/" + notificationId).with(csrf()))
+                .andExpect(status().isOk());
     }
 
     @Test
     @WithMockUser(username = "00000000-0000-0000-0000-000000000001", roles = {"USER"})
     void testDeleteNotificationNotFound() throws Exception {
+        UUID userId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID notificationId = UUID.randomUUID();
+        Mockito.doThrow(new Exception("Notification not found"))
+                .when(notificationService).deleteNotification(notificationId, userId);
+
+        mockMvc.perform(delete("/notifications/" + notificationId).with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Notification not found"));
     }
 }

--- a/src/test/java/id/ac/ui/cs/advprog/order/model/NotificationTest.java
+++ b/src/test/java/id/ac/ui/cs/advprog/order/model/NotificationTest.java
@@ -1,14 +1,49 @@
 package id.ac.ui.cs.advprog.order.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 
 public class NotificationTest {
 
     @Test
     void testNotificationCreationDefault() {
+        UUID userId = UUID.randomUUID();
+        String title = "Repair Completed";
+        String message = "Your repair has been completed successfully.";
+        Notification notification = new Notification(userId, title, message);
+
+        assertEquals(userId, notification.getUserId());
+        assertEquals(title, notification.getTitle());
+        assertEquals(message, notification.getMessage());
+        assertFalse(notification.isRead());
+        assertNotNull(notification.getCreatedAt());
     }
 
     @Test
     void testNotificationSetters() {
+        Notification notification = new Notification();
+        UUID userId = UUID.randomUUID();
+        notification.setUserId(userId);
+        notification.setTitle("New Title");
+        notification.setMessage("New Message");
+        notification.setRead(true);
+        LocalDateTime now = LocalDateTime.now();
+        notification.setCreatedAt(now);
+        UUID newId = UUID.randomUUID();
+        notification.setId(newId);
+
+        assertEquals(userId, notification.getUserId());
+        assertEquals("New Title", notification.getTitle());
+        assertEquals("New Message", notification.getMessage());
+        assertTrue(notification.isRead());
+        assertEquals(now, notification.getCreatedAt());
+        assertEquals(newId, notification.getId());
     }
 }

--- a/src/test/java/id/ac/ui/cs/advprog/order/model/NotificationTest.java
+++ b/src/test/java/id/ac/ui/cs/advprog/order/model/NotificationTest.java
@@ -1,0 +1,14 @@
+package id.ac.ui.cs.advprog.order.model;
+
+import org.junit.jupiter.api.Test;
+
+public class NotificationTest {
+
+    @Test
+    void testNotificationCreationDefault() {
+    }
+
+    @Test
+    void testNotificationSetters() {
+    }
+}

--- a/src/test/java/id/ac/ui/cs/advprog/order/repository/NotificationRepositoryTest.java
+++ b/src/test/java/id/ac/ui/cs/advprog/order/repository/NotificationRepositoryTest.java
@@ -1,8 +1,17 @@
 package id.ac.ui.cs.advprog.order.repository;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import id.ac.ui.cs.advprog.order.model.Notification;
 
 @DataJpaTest
 public class NotificationRepositoryTest {
@@ -12,5 +21,16 @@ public class NotificationRepositoryTest {
 
     @Test
     void testSaveAndFindByUserId() {
+        UUID userId = UUID.randomUUID();
+        String title = "Repair Completed";
+        String message = "Your repair is complete.";
+        Notification notification = new Notification(userId, title, message);
+        notification = notificationRepository.save(notification);
+        assertNotNull(notification.getId());
+
+        List<Notification> notifications = notificationRepository.findByUserId(userId);
+        assertFalse(notifications.isEmpty());
+        assertEquals(title, notifications.get(0).getTitle());
+        assertEquals(message, notifications.get(0).getMessage());
     }
 }

--- a/src/test/java/id/ac/ui/cs/advprog/order/repository/NotificationRepositoryTest.java
+++ b/src/test/java/id/ac/ui/cs/advprog/order/repository/NotificationRepositoryTest.java
@@ -1,0 +1,16 @@
+package id.ac.ui.cs.advprog.order.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Test
+    void testSaveAndFindByUserId() {
+    }
+}

--- a/src/test/java/id/ac/ui/cs/advprog/order/service/NotificationServiceTest.java
+++ b/src/test/java/id/ac/ui/cs/advprog/order/service/NotificationServiceTest.java
@@ -1,0 +1,36 @@
+package id.ac.ui.cs.advprog.order.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import id.ac.ui.cs.advprog.order.repository.NotificationRepository;
+
+public class NotificationServiceTest {
+
+    private NotificationRepository notificationRepository;
+    private NotificationServiceImpl notificationService;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void testCreateNotification() {
+    }
+
+    @Test
+    void testGetNotificationsMarksAsRead() {
+    }
+
+    @Test
+    void testDeleteNotificationSuccess() throws Exception {
+    }
+
+    @Test
+    void testDeleteNotificationNotFound() {
+    }
+
+    @Test
+    void testDeleteNotificationNotAuthorized() {
+    }
+}

--- a/src/test/java/id/ac/ui/cs/advprog/order/service/NotificationServiceTest.java
+++ b/src/test/java/id/ac/ui/cs/advprog/order/service/NotificationServiceTest.java
@@ -1,8 +1,26 @@
 package id.ac.ui.cs.advprog.order.service;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import id.ac.ui.cs.advprog.order.model.Notification;
 import id.ac.ui.cs.advprog.order.repository.NotificationRepository;
 
 public class NotificationServiceTest {
@@ -12,25 +30,77 @@ public class NotificationServiceTest {
 
     @BeforeEach
     void setUp() {
+        notificationRepository = Mockito.mock(NotificationRepository.class);
+        notificationService = new NotificationServiceImpl(notificationRepository);
     }
 
     @Test
     void testCreateNotification() {
+        UUID userId = UUID.randomUUID();
+        String title = "Repair Completed";
+        String message = "Your repair is complete.";
+        Notification notification = new Notification(userId, title, message);
+        when(notificationRepository.save(any(Notification.class))).thenReturn(notification);
+
+        Notification created = notificationService.createNotification(userId, title, message);
+        assertNotNull(created);
+        assertEquals(userId, created.getUserId());
+        assertEquals(title, created.getTitle());
+        assertEquals(message, created.getMessage());
+        assertFalse(created.isRead());
     }
 
     @Test
     void testGetNotificationsMarksAsRead() {
+        UUID userId = UUID.randomUUID();
+        String title = "Repair Completed";
+        String message = "Your repair is complete.";
+        Notification n1 = new Notification(userId, title, message);
+        Notification n2 = new Notification(userId, title, message);
+        n1.setRead(false);
+        n2.setRead(false);
+        when(notificationRepository.findByUserId(userId)).thenReturn(Arrays.asList(n1, n2));
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var notifications = notificationService.getNotifications(userId);
+        for (Notification n : notifications) {
+            assertTrue(n.isRead());
+        }
     }
 
     @Test
     void testDeleteNotificationSuccess() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+        Notification notification = new Notification(userId, "Title", "Message");
+        notification.setId(notificationId);
+        when(notificationRepository.findById(notificationId)).thenReturn(Optional.of(notification));
+        doNothing().when(notificationRepository).deleteById(notificationId);
+
+        assertDoesNotThrow(() -> notificationService.deleteNotification(notificationId, userId));
+        verify(notificationRepository, times(1)).deleteById(notificationId);
     }
 
     @Test
     void testDeleteNotificationNotFound() {
+        UUID userId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+        when(notificationRepository.findById(notificationId)).thenReturn(Optional.empty());
+
+        Exception ex = assertThrows(Exception.class, () -> notificationService.deleteNotification(notificationId, userId));
+        assertTrue(ex.getMessage().contains("Notification not found"));
     }
 
     @Test
     void testDeleteNotificationNotAuthorized() {
+        UUID userId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+        Notification notification = new Notification(otherUserId, "Title", "Message");
+        notification.setId(notificationId);
+        when(notificationRepository.findById(notificationId)).thenReturn(Optional.of(notification));
+
+        Exception ex = assertThrows(Exception.class, () -> notificationService.deleteNotification(notificationId, userId));
+        assertTrue(ex.getMessage().contains("Not authorized"));
     }
 }


### PR DESCRIPTION
#### Description
This PR introduces a notification feature that informs users when technicians have completed repairs. Users can now access a list of all notifications associated with their accounts, mark notifications as read upon viewing, and delete notifications to manage their notification history. Security configurations have been updated to ensure only authenticated users with the USER role can access notifications. Additionally, comprehensive unit tests have been included to validate all new functionalities and ensure robustness of the notification system.

#### Related Issues
- Implements mandatory notification feature for completed repairs.

#### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation update
- [ ] Test update
- [ ] Breaking change

#### Checklist
- [x] Code reviewed and tested locally
- [x] Tests added or updated
- [x] Documentation updated
- [ ] Changelog updated (if applicable)
- [x] Code adheres to coding standards and style guidelines